### PR TITLE
Feat[#31] 약속 만드는 팝오버(AddPromisePopover.swift)를 입력값에 따라 부모, 아이용으로 바뀌도록 수정할게요.

### DIFF
--- a/kko_okk.xcodeproj/project.pbxproj
+++ b/kko_okk.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		A8C834C62848A37D00C65BE0 /* WeeklyReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C834C52848A37D00C65BE0 /* WeeklyReportView.swift */; };
 		A8C834C82848A38C00C65BE0 /* MonthlyReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C834C72848A38C00C65BE0 /* MonthlyReportView.swift */; };
 		A8C834CA2848A39200C65BE0 /* CountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C834C92848A39200C65BE0 /* CountView.swift */; };
+		F87E1F90284B2D5900AD05B3 /* Subject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87E1F8F284B2D5900AD05B3 /* Subject.swift */; };
+		F87E1F92284B2FA700AD05B3 /* EditPromisePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87E1F91284B2FA700AD05B3 /* EditPromisePopover.swift */; };
 		F89CAB772849D761006C72BD /* AddPromisePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89CAB762849D761006C72BD /* AddPromisePopover.swift */; };
 /* End PBXBuildFile section */
 
@@ -89,6 +91,8 @@
 		A8C834C52848A37D00C65BE0 /* WeeklyReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WeeklyReportView.swift; path = kko_okk/Views/BoardViews/WeeklyReportView.swift; sourceTree = SOURCE_ROOT; };
 		A8C834C72848A38C00C65BE0 /* MonthlyReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MonthlyReportView.swift; path = kko_okk/Views/BoardViews/MonthlyReportView.swift; sourceTree = SOURCE_ROOT; };
 		A8C834C92848A39200C65BE0 /* CountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CountView.swift; path = kko_okk/Views/BoardViews/CountView.swift; sourceTree = SOURCE_ROOT; };
+		F87E1F8F284B2D5900AD05B3 /* Subject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subject.swift; sourceTree = "<group>"; };
+		F87E1F91284B2FA700AD05B3 /* EditPromisePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPromisePopover.swift; sourceTree = "<group>"; };
 		F89CAB762849D761006C72BD /* AddPromisePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPromisePopover.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -123,6 +127,7 @@
 				22E9001C2848EE45000A82BE /* Promise+CoreDataClass.swift */,
 				22E9001D2848EE45000A82BE /* Promise+CoreDataProperties.swift */,
 				221CC2C328479F74009F4851 /* TipModel.swift */,
+				F87E1F8F284B2D5900AD05B3 /* Subject.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -208,6 +213,7 @@
 				9DEB3A2528462A240001959A /* ContractView.swift */,
 				9DEB3A2728462A4B0001959A /* ButtonForContract.swift */,
 				F89CAB762849D761006C72BD /* AddPromisePopover.swift */,
+				F87E1F91284B2FA700AD05B3 /* EditPromisePopover.swift */,
 				22E9005D2849D677000A82BE /* FilteredList.swift */,
 			);
 			path = TodoTab;
@@ -406,12 +412,14 @@
 				A8C834A828471D0400C65BE0 /* Style.swift in Sources */,
 				9DEB3A21284629E30001959A /* ParentWishView.swift in Sources */,
 				9DEB3A2828462A4B0001959A /* ButtonForContract.swift in Sources */,
+				F87E1F92284B2FA700AD05B3 /* EditPromisePopover.swift in Sources */,
 				221CC2C428479F74009F4851 /* TipModel.swift in Sources */,
 				22E9005E2849D677000A82BE /* FilteredList.swift in Sources */,
 				A8C834CA2848A39200C65BE0 /* CountView.swift in Sources */,
 				9D55B40E2846289100AFD9C5 /* Persistence.swift in Sources */,
 				A8C834C22848A34E00C65BE0 /* SettingView.swift in Sources */,
 				9D55B4112846289100AFD9C5 /* kko_okk.xcdatamodeld in Sources */,
+				F87E1F90284B2D5900AD05B3 /* Subject.swift in Sources */,
 				9DEB3A3128462AA10001959A /* TodoBoardView.swift in Sources */,
 				9D55B4072846289000AFD9C5 /* ContentView.swift in Sources */,
 				A8C834A028471AA300C65BE0 /* SegmentView.swift in Sources */,

--- a/kko_okk/Models/Subject.swift
+++ b/kko_okk/Models/Subject.swift
@@ -1,0 +1,12 @@
+//
+//  Subject.swift
+//  kko_okk
+//
+//  Created by Seodam on 2022/06/04.
+//
+
+import Foundation
+
+enum Subject {
+    case parent, child
+}

--- a/kko_okk/Views/BoardViews/TodoTab/AddPromisePopover.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/AddPromisePopover.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 struct AddPromisePopover: View {
+    // Subject enum이 .parent인지 .child인지에 따라 뷰의 기능이 달라짐.
+    var subject: Subject
+    
     // viewContext 받아오기
     @Environment(\.managedObjectContext) private var viewContext
     
@@ -32,7 +35,12 @@ struct AddPromisePopover: View {
                 
                 Spacer()
                 
-                Text("약속 만들기")
+                switch subject {
+                case .parent:
+                    Text("부모의 약속 만들기")
+                case .child:
+                    Text("아이의 약속 만들기")
+                }
                 
                 Spacer()
                 
@@ -112,8 +120,13 @@ struct AddPromisePopover: View {
             promise.isDone = false
             promise.isRepeat = false
             
-            // 일단 "parent"로 넣어두고, 나중에 부모-아이용, 약속 만들기-수정하기 용도로 재활용하는 방법 고안하기
-            promise.subject = "parent"
+            switch subject {
+            case .parent:
+                promise.subject = "parent"
+            case .child:
+                promise.subject = "child"
+            }
+
             promise.repeatType = ""
             
             do {

--- a/kko_okk/Views/BoardViews/TodoTab/ChildWishView.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ChildWishView.swift
@@ -10,85 +10,36 @@ import SwiftUI
 
 struct ChildWishView: View {
     @Environment(\.managedObjectContext) private var viewContext
-
+    
     @FetchRequest(sortDescriptors: [], animation: .default)
     private var items: FetchedResults<Promise>
+    
+    // Popover 띄우고 닫을 용도
+    @State private var isShowingPopover: Bool = false
     
     var body: some View {
         VStack {
             HStack {
                 TextField("아이용", text: .constant(""))
                     .padding(.leading, 10)
-
-                Button(action: addItem) {
-
-//                 Circle()
-//                     .fill(Color.gray.opacity(0.4))
-//                     .frame(width: 20, height: 20)
-//                     .overlay(
-//                         // 원 안의 숫자는 state-binding으로 컬럼 내 액티브 버튼 갯수가 저장된 변수에 묶어야 함. 지금은 임시로 넣어 놓은 상태.
-//                         Text("1")
-//                             .font(.system(size: 10))
-//                     )
                 
-//                 Spacer()
-//                     .frame(width: 50, height: 30)
-                
-//                 Button(action: {
-//                     print("Add button tapped")
-//                 }) {
+                Button {
+                    isShowingPopover.toggle()
+                } label: {
                     Image(systemName: "plus")
                         .frame(width: 30, height: 30)
                 }
+                .popover(isPresented: $isShowingPopover) {
+                    AddPromisePopover(subject: .child, isShowingPopover: $isShowingPopover)
+                }
             }
             .padding(.trailing, 10)
-
+            
             Divider()
-
+            
             Spacer()
             // 약속이 안된 것
             FilteredList(filter: "child", formatter: "promised == FALSE")
-        }
-    }
-    private func addItem() {
-        withAnimation {
-            let promise = Promise(context: viewContext)
-            promise.id = UUID()
-            promise.name = "약속"
-            promise.memo = "약속을 만들었다"
-            promise.madeTime = Date()
-            promise.promised = false
-            promise.parentCheck = false
-            promise.childCheck = false
-            promise.isDone = false
-            promise.isRepeat = false
-            promise.subject = "child"
-            promise.repeatType = ""
-
-            do {
-                try viewContext.save()
-            } catch {
-                let nsError = error as NSError
-                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-            }
-        }
-    }
-
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            
-            for index in offsets {
-                let item = items[index]
-                viewContext.delete(item)
-                break
-            }
-//            viewContext.delete()
-            do {
-                try viewContext.save()
-            } catch {
-                let nsError = error as NSError
-                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-            }
         }
     }
 }

--- a/kko_okk/Views/BoardViews/TodoTab/EditPromisePopover.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/EditPromisePopover.swift
@@ -1,0 +1,147 @@
+////
+////  EditPromisePopover.swift
+////  kko_okk
+////
+////  Created by Seodam on 2022/06/04.
+////
+//
+//import SwiftUI
+//
+//struct EditPromisePopover: View {
+//    // Subject enum이 .parent인지 .child인지에 따라 뷰의 기능이 달라짐.
+//    var subject: Subject
+//    
+//    // viewContext 받아오기
+//    @Environment(\.managedObjectContext) private var viewContext
+//    
+//    // popover 띄우고 닫을 변수
+//    @Binding var isShowingPopover: Bool
+//    
+//    //
+//    @State var name: String = "할 일"
+//    @State var memo: String = "상세 내용"
+//    
+//    // 반복 가능 요일
+//    let days: [String] = ["월요일", "화요일", "수요일", "목요일", "금요일", "토요일", "일요일"]
+//    
+//    var body: some View {
+//        VStack {
+//            HStack {
+//                Button {
+//                    isShowingPopover.toggle()
+//                } label: {
+//                    Text("취소")
+//                }
+//                
+//                Spacer()
+//                
+//                switch subject {
+//                case .parent:
+//                    Text("부모의 약속 만들기")
+//                case .child:
+//                    Text("아이의 약속 만들기")
+//                }
+//                
+//                Spacer()
+//                
+//                Button {
+//                    addPromise()
+//                    isShowingPopover.toggle()
+//                } label: {
+//                    Text("완료")
+//                }
+//            }
+//            .padding()
+//            .font(.title3)
+//            
+//            HStack {
+//                Text("할 일 정하기")
+//                    .font(.largeTitle)
+//                    .fontWeight(.bold)
+//                Spacer()
+//            }
+//            
+//            ZStack {
+//                RoundedRectangle(cornerRadius: 15)
+//                    .frame(width: .infinity, height: 200)
+//                    .foregroundColor(.white)
+//                
+//                VStack {
+//                    TextField("", text: $name)
+//                        .background(.white)
+//                        .cornerRadius(15)
+//                        .padding(.horizontal, 13)
+//                    
+//                    Divider()
+//                        .padding(.horizontal, 8)
+//                        .foregroundColor(.gray)
+//                    
+//                    TextEditor(text: $memo)
+//                        .frame(width: .infinity, height: 130)
+//                        .cornerRadius(15)
+//                        .padding(.horizontal, 8)
+//                }
+//            }
+//            HStack {
+//                Text("반복")
+//                    .font(.largeTitle)
+//                    .fontWeight(.bold)
+//                Spacer()
+//            }
+//            
+//            HStack {
+//                ForEach(days, id: \.self) { day in
+//                    Button(action: {
+//                        
+//                    }, label: {
+//                        Text(day)
+//                            .foregroundColor(.black)
+//                    })
+//                    .buttonStyle(.bordered)
+//                    .padding(.horizontal)
+//                }
+//            }
+//        }
+//        .padding()
+//        .frame(width: 800, height: 500)
+//        .background(.bar)
+//    }
+//    
+//    private func addPromise() {
+//        withAnimation {
+//            let promise = Promise(context: viewContext)
+//            promise.id = UUID()
+//            promise.name = name
+//            promise.memo = memo
+//            promise.madeTime = Date()
+//            promise.promised = false
+//            promise.parentCheck = false
+//            promise.childCheck = false
+//            promise.isDone = false
+//            promise.isRepeat = false
+//            
+//            switch subject {
+//            case .parent:
+//                promise.subject = "parent"
+//            case .child:
+//                promise.subject = "child"
+//            }
+//
+//            promise.repeatType = ""
+//            
+//            do {
+//                try viewContext.save()
+//            } catch {
+//                let nsError = error as NSError
+//                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+//            }
+//        }
+//    }
+//}
+//
+////struct AddWishPopover_Previews: PreviewProvider {
+////    static var previews: some View {
+////        AddPromisePopover()
+////            .previewInterfaceOrientation(.landscapeRight)
+////    }
+////}

--- a/kko_okk/Views/BoardViews/TodoTab/FilteredList.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/FilteredList.swift
@@ -19,7 +19,13 @@ struct FilteredList: View {
             Text(nowSubject)
             List {
                 ForEach(fetchRequest) { item in
-                    Text(item.name ?? "Unknown")
+                    HStack {
+                        Text(item.name ?? "Unknown")
+                        
+                        Spacer()
+                        
+                        Image(systemName: "ellipsis")
+                    }
                 }
                 .onDelete(perform: deleteItems)
             }

--- a/kko_okk/Views/BoardViews/TodoTab/ParentWishView.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ParentWishView.swift
@@ -9,7 +9,6 @@ import Foundation
 import SwiftUI
 
 struct ParentWishView: View {
-    
     @Environment(\.managedObjectContext) private var viewContext
 
     @FetchRequest(
@@ -17,29 +16,23 @@ struct ParentWishView: View {
         animation: .default)
     private var items: FetchedResults<Promise>
     
+    // Popover 띄우고 닫을 용도
+    @State private var isShowingPopover: Bool = false
+    
     var body: some View {
         VStack {
             HStack {
                 TextField("부모용", text: .constant(""))
                     .padding(.leading, 10)
 
-                Button(action: addItem) {
-//                 Circle()
-//                     .fill(Color.gray.opacity(0.4))
-//                     .frame(width: 20, height: 20)
-//                     .overlay(
-//                         Text("1")
-//                             .font(.system(size: 10))
-//                     )
-                
-//                 Spacer()
-//                     .frame(width: 50, height: 30)
-
-//                 Button(action: {
-//                     print("Add button tapped")
-//                 }) {
+                Button {
+                    isShowingPopover.toggle()
+                } label: {
                     Image(systemName: "plus")
                         .frame(width: 30, height: 30)
+                }
+                .popover(isPresented: $isShowingPopover) {
+                    AddPromisePopover(subject: .parent, isShowingPopover: $isShowingPopover)
                 }
             }
             .padding(.trailing, 10)
@@ -49,48 +42,6 @@ struct ParentWishView: View {
             Spacer()
             // 약속이 안된 것
             FilteredList(filter: "parent", formatter: "promised == FALSE")
-        }
-    }
-    private func addItem() {
-        withAnimation {
-            let promise = Promise(context: viewContext)
-            promise.id = UUID()
-            promise.name = "약속"
-            promise.memo = "약속을 만들었다"
-            promise.madeTime = Date()
-            promise.promised = false
-            promise.parentCheck = false
-            promise.childCheck = false
-            promise.isDone = false
-            promise.isRepeat = false
-            promise.subject = "parent"
-            promise.repeatType = ""
-
-            do {
-                try viewContext.save()
-            } catch {
-                let nsError = error as NSError
-                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-            }
-        }
-    }
-
-    private func deleteItems(offsets: IndexSet) {
-        print(offsets)
-        withAnimation {
-            for index in offsets {
-                let item = items[index]
-                viewContext.delete(item)
-                break
-            }
-//            offsets.map { items[$0] }.forEach(viewContext.delete)
-            
-            do {
-                try viewContext.save()
-            } catch {
-                let nsError = error as NSError
-                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
아이와 부모의 약속 만들기의 기능은 대부분 공통인데, 약간 다른 부분이 있음. (팝오버 제목, promise.subject attribute)
enum 값에 따라 해당 부분만 바꿔주면 대부분의 코드를 재사용할 수 있음.
### Key changes
AddPromisePopover 뷰의 입력값으로 subject가 들어감. 가능한 값은 .parent와 .child
ex) AddPromisePopover(subject: .parent)