### PR TITLE
Feat[#38] 약속 수정하는 기능 추가 

### DIFF
--- a/kko_okk.xcodeproj/project.pbxproj
+++ b/kko_okk.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		A8C834CA2848A39200C65BE0 /* CountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C834C92848A39200C65BE0 /* CountView.swift */; };
 		F87E1F90284B2D5900AD05B3 /* Subject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87E1F8F284B2D5900AD05B3 /* Subject.swift */; };
 		F87E1F92284B2FA700AD05B3 /* EditPromisePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87E1F91284B2FA700AD05B3 /* EditPromisePopover.swift */; };
+		F889B519284C797B006DFEFC /* PromiseCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F889B518284C797B006DFEFC /* PromiseCell.swift */; };
 		F89CAB772849D761006C72BD /* AddPromisePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89CAB762849D761006C72BD /* AddPromisePopover.swift */; };
 /* End PBXBuildFile section */
 
@@ -142,6 +143,7 @@
 		A8C834C92848A39200C65BE0 /* CountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CountView.swift; path = kko_okk/Views/BoardViews/CountView.swift; sourceTree = SOURCE_ROOT; };
 		F87E1F8F284B2D5900AD05B3 /* Subject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subject.swift; sourceTree = "<group>"; };
 		F87E1F91284B2FA700AD05B3 /* EditPromisePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPromisePopover.swift; sourceTree = "<group>"; };
+		F889B518284C797B006DFEFC /* PromiseCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseCell.swift; sourceTree = "<group>"; };
 		F89CAB762849D761006C72BD /* AddPromisePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPromisePopover.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -265,6 +267,7 @@
 				F89CAB762849D761006C72BD /* AddPromisePopover.swift */,
 				F87E1F91284B2FA700AD05B3 /* EditPromisePopover.swift */,
 				22E9005D2849D677000A82BE /* FilteredList.swift */,
+				F889B518284C797B006DFEFC /* PromiseCell.swift */,
 			);
 			path = TodoTab;
 			sourceTree = "<group>";
@@ -513,6 +516,7 @@
 				9DEB3A2828462A4B0001959A /* ButtonForContract.swift in Sources */,
 				F87E1F92284B2FA700AD05B3 /* EditPromisePopover.swift in Sources */,
 				221CC2C428479F74009F4851 /* TipModel.swift in Sources */,
+				F889B519284C797B006DFEFC /* PromiseCell.swift in Sources */,
 				22E9005E2849D677000A82BE /* FilteredList.swift in Sources */,
 				A8C834CA2848A39200C65BE0 /* CountView.swift in Sources */,
 				9D55B40E2846289100AFD9C5 /* Persistence.swift in Sources */,

--- a/kko_okk/Views/BoardViews/TodoTab/AddPromisePopover.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/AddPromisePopover.swift
@@ -17,7 +17,7 @@ struct AddPromisePopover: View {
     // popover 띄우고 닫을 변수
     @Binding var isShowingPopover: Bool
     
-    //
+    // 완료 버튼을 누르기 전까지 임시 값을 저장하는 변수
     @State var name: String = "할 일"
     @State var memo: String = "상세 내용"
     
@@ -28,6 +28,7 @@ struct AddPromisePopover: View {
         VStack {
             HStack {
                 Button {
+                    // Popover 띄우기
                     isShowingPopover.toggle()
                 } label: {
                     Text("취소")
@@ -35,6 +36,7 @@ struct AddPromisePopover: View {
                 
                 Spacer()
                 
+                // 입력받은 enum 값에 따라 popover 상단 바의 제목을 바꿔주기.
                 switch subject {
                 case .parent:
                     Text("부모의 약속 만들기")
@@ -45,7 +47,10 @@ struct AddPromisePopover: View {
                 Spacer()
                 
                 Button {
+                    // name, memo 변수에 저장되어 있는 임시값으로 CoreData에 새로운 Promise를 생성, 저장.
                     addPromise()
+                    
+                    // Popover 닫기
                     isShowingPopover.toggle()
                 } label: {
                     Text("완료")
@@ -62,11 +67,13 @@ struct AddPromisePopover: View {
             }
             
             ZStack {
+                // name, memo 텍스트필드를 붙어있는 것처럼 만들기 위한 사각형
                 RoundedRectangle(cornerRadius: 15)
-                    .frame(width: .infinity, height: 200)
+                    .frame(width: 760, height: 200)
                     .foregroundColor(.white)
                 
                 VStack {
+                    // name 수정하는 영역
                     TextField("", text: $name)
                         .background(.white)
                         .cornerRadius(15)
@@ -76,12 +83,15 @@ struct AddPromisePopover: View {
                         .padding(.horizontal, 8)
                         .foregroundColor(.gray)
                     
+                    // memo 수정하는 영역
                     TextEditor(text: $memo)
-                        .frame(width: .infinity, height: 130)
+                        .frame(width: 760, height: 130)
                         .cornerRadius(15)
                         .padding(.horizontal, 8)
                 }
             }
+            
+            // 반복 날짜 선택 버튼
             HStack {
                 Text("반복")
                     .font(.largeTitle)
@@ -107,6 +117,7 @@ struct AddPromisePopover: View {
         .background(.bar)
     }
     
+    // name, memo 변수에 저장되어 있는 임시값으로 CoreData에 새로운 Promise를 생성, 저장.
     private func addPromise() {
         withAnimation {
             let promise = Promise(context: viewContext)
@@ -120,6 +131,7 @@ struct AddPromisePopover: View {
             promise.isDone = false
             promise.isRepeat = false
             
+            // AddPromisePopover가 입력받은 subject enum 값에 따라 promise.subject 값을 다르게 설정. 
             switch subject {
             case .parent:
                 promise.subject = "parent"

--- a/kko_okk/Views/BoardViews/TodoTab/EditPromisePopover.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/EditPromisePopover.swift
@@ -1,147 +1,140 @@
-////
-////  EditPromisePopover.swift
-////  kko_okk
-////
-////  Created by Seodam on 2022/06/04.
-////
 //
-//import SwiftUI
+//  EditPromisePopover.swift
+//  kko_okk
 //
-//struct EditPromisePopover: View {
-//    // Subject enum이 .parent인지 .child인지에 따라 뷰의 기능이 달라짐.
-//    var subject: Subject
-//    
-//    // viewContext 받아오기
-//    @Environment(\.managedObjectContext) private var viewContext
-//    
-//    // popover 띄우고 닫을 변수
-//    @Binding var isShowingPopover: Bool
-//    
-//    //
-//    @State var name: String = "할 일"
-//    @State var memo: String = "상세 내용"
-//    
-//    // 반복 가능 요일
-//    let days: [String] = ["월요일", "화요일", "수요일", "목요일", "금요일", "토요일", "일요일"]
-//    
-//    var body: some View {
-//        VStack {
-//            HStack {
-//                Button {
-//                    isShowingPopover.toggle()
-//                } label: {
-//                    Text("취소")
-//                }
-//                
-//                Spacer()
-//                
-//                switch subject {
-//                case .parent:
-//                    Text("부모의 약속 만들기")
-//                case .child:
-//                    Text("아이의 약속 만들기")
-//                }
-//                
-//                Spacer()
-//                
-//                Button {
-//                    addPromise()
-//                    isShowingPopover.toggle()
-//                } label: {
-//                    Text("완료")
-//                }
-//            }
-//            .padding()
-//            .font(.title3)
-//            
-//            HStack {
-//                Text("할 일 정하기")
-//                    .font(.largeTitle)
-//                    .fontWeight(.bold)
-//                Spacer()
-//            }
-//            
-//            ZStack {
-//                RoundedRectangle(cornerRadius: 15)
-//                    .frame(width: .infinity, height: 200)
-//                    .foregroundColor(.white)
-//                
-//                VStack {
-//                    TextField("", text: $name)
-//                        .background(.white)
-//                        .cornerRadius(15)
-//                        .padding(.horizontal, 13)
-//                    
-//                    Divider()
-//                        .padding(.horizontal, 8)
-//                        .foregroundColor(.gray)
-//                    
-//                    TextEditor(text: $memo)
-//                        .frame(width: .infinity, height: 130)
-//                        .cornerRadius(15)
-//                        .padding(.horizontal, 8)
-//                }
-//            }
-//            HStack {
-//                Text("반복")
-//                    .font(.largeTitle)
-//                    .fontWeight(.bold)
-//                Spacer()
-//            }
-//            
-//            HStack {
-//                ForEach(days, id: \.self) { day in
-//                    Button(action: {
-//                        
-//                    }, label: {
-//                        Text(day)
-//                            .foregroundColor(.black)
-//                    })
-//                    .buttonStyle(.bordered)
-//                    .padding(.horizontal)
-//                }
-//            }
-//        }
-//        .padding()
-//        .frame(width: 800, height: 500)
-//        .background(.bar)
-//    }
-//    
-//    private func addPromise() {
-//        withAnimation {
-//            let promise = Promise(context: viewContext)
-//            promise.id = UUID()
-//            promise.name = name
-//            promise.memo = memo
-//            promise.madeTime = Date()
-//            promise.promised = false
-//            promise.parentCheck = false
-//            promise.childCheck = false
-//            promise.isDone = false
-//            promise.isRepeat = false
-//            
-//            switch subject {
-//            case .parent:
-//                promise.subject = "parent"
-//            case .child:
-//                promise.subject = "child"
-//            }
+//  Created by Seodam on 2022/06/04.
 //
-//            promise.repeatType = ""
-//            
-//            do {
-//                try viewContext.save()
-//            } catch {
-//                let nsError = error as NSError
-//                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-//            }
-//        }
+
+import SwiftUI
+
+struct EditPromisePopover: View {
+    // PromiseCell로부터 약속 받아오기
+    @ObservedObject var promise: Promise
+    
+    // viewContext 받아오기
+    @Environment(\.managedObjectContext) private var viewContext
+    
+    // popover 띄우고 닫을 변수
+    @Binding var isPresented: Bool
+    
+    // 완료 버튼을 누르기 전까지 임시 값을 저장하는 변수
+    @State var name: String = ""
+    @State var memo: String = ""
+    
+    // 반복 가능 요일
+    let days: [String] = ["월요일", "화요일", "수요일", "목요일", "금요일", "토요일", "일요일"]
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Button {
+                    // Popover 열기
+                    isPresented.toggle()
+                } label: {
+                    Text("취소")
+                }
+                
+                Spacer()
+                
+                Text("약속 수정하기")
+                
+                Spacer()
+                
+                Button {
+                    // name, memo 변수에 저장되어 있는 임시값을 CoreData에 업데이트
+                    updatePromise(promise: promise)
+                    
+                    // Popover 닫기
+                    isPresented.toggle()
+                } label: {
+                    Text("완료")
+                }
+            }
+            .padding()
+            .font(.title3)
+            
+            HStack {
+                Text("할 일 정하기")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                Spacer()
+            }
+            
+            ZStack {
+                // name, memo 텍스트필드를 붙어있는 것처럼 만들기 위한 사각형
+                RoundedRectangle(cornerRadius: 15)
+                    .frame(width: 760, height: 200)
+                    .foregroundColor(.white)
+                
+                VStack {
+                    // name 수정하는 영역
+                    TextField("", text: $name)
+                        .background(.white)
+                        .cornerRadius(15)
+                        .padding(.horizontal, 13)
+                    
+                    Divider()
+                        .padding(.horizontal, 8)
+                        .foregroundColor(.gray)
+                    
+                    // memo 수정하는 영역
+                    TextEditor(text: $memo)
+                        .frame(width: 760, height: 130)
+                        .cornerRadius(15)
+                        .padding(.horizontal, 8)
+                }
+            }
+            
+            // 반복 날짜 선택 버튼
+            HStack {
+                Text("반복")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                Spacer()
+            }
+            
+            HStack {
+                ForEach(days, id: \.self) { day in
+                    Button(action: {
+                        
+                    }, label: {
+                        Text(day)
+                            .foregroundColor(.black)
+                    })
+                    .buttonStyle(.bordered)
+                    .padding(.horizontal)
+                }
+            }
+        }
+        .onAppear() {
+            // 뷰를 그릴 때, 받아온 약속의 name, memo 값을 임시값에 저장
+            name = promise.name ?? ""
+            memo = promise.memo ?? ""
+        }
+        .padding()
+        .frame(width: 800, height: 500)
+        .background(.bar)
+    }
+    
+    // name, memo 변수에 저장되어 있는 임시값을 CoreData에 업데이트.
+    private func updatePromise(promise: Promise) {
+        withAnimation {
+            promise.name = name
+            promise.memo = memo
+
+            do {
+                try viewContext.save()
+            } catch {
+                let nsError = error as NSError
+                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+            }
+        }
+    }
+}
+
+//struct AddWishPopover_Previews: PreviewProvider {
+//    static var previews: some View {
+//        AddPromisePopover()
+//            .previewInterfaceOrientation(.landscapeRight)
 //    }
 //}
-//
-////struct AddWishPopover_Previews: PreviewProvider {
-////    static var previews: some View {
-////        AddPromisePopover()
-////            .previewInterfaceOrientation(.landscapeRight)
-////    }
-////}

--- a/kko_okk/Views/BoardViews/TodoTab/FilteredList.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/FilteredList.swift
@@ -9,23 +9,25 @@
 import SwiftUI
 
 struct FilteredList: View {
+    // CoreData 사용을 위해 viewContext 받아오기
     @Environment(\.managedObjectContext) private var viewContext
     
+    // CoreData에 저장된 Promise 값 불러오기
     @FetchRequest(sortDescriptors: [], animation: .default)
     private var fetchRequest: FetchedResults<Promise>
+    
+    // 부모의 약속인지 아이의 약속인지 구분하기 위한 String. 부모: "parent", 아이: "child"
     private var nowSubject: String = ""
+    
+    // Popover 띄우고 닫는 용도
+    @State private var isShowingPopover: Bool = false
+    
     var body: some View {
         VStack {
             Text(nowSubject)
             List {
                 ForEach(fetchRequest) { item in
-                    HStack {
-                        Text(item.name ?? "Unknown")
-                        
-                        Spacer()
-                        
-                        Image(systemName: "ellipsis")
-                    }
+                   PromiseCell(promise: item)
                 }
                 .onDelete(perform: deleteItems)
             }

--- a/kko_okk/Views/BoardViews/TodoTab/PromiseCell.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/PromiseCell.swift
@@ -1,0 +1,53 @@
+//
+//  PromiseCell.swift
+//  kko_okk
+//
+//  Created by 임성균 on 2022/06/05.
+//
+
+import SwiftUI
+
+struct PromiseCell: View {
+    // FilteredList로부터 약속(Promise) 전달받기
+    @ObservedObject var promise: Promise
+    
+    // Popover 띄우고 닫는 용도
+    @State private var isShowingPopover: Bool = false
+    
+    var body: some View {
+        HStack {
+            Text(promise.name ?? "Unknown")
+            
+            Spacer()
+            
+            // 약속 수정하기 버튼
+            ZStack {
+                // 버튼 아이콘
+                Image(systemName: "ellipsis")
+                    .resizable()
+                    .frame(width: 30, height: 6)
+                    .rotationEffect(.degrees(90))
+                    .foregroundColor(.black)
+                
+                // 버튼 아이콘의 사이즈가 작아서, 위에 투명한 사각형을 덧댐.
+                Rectangle()
+                    .fill(parentColor.opacity(0.0))
+                    .frame(width: 40, height: 40)
+            }
+            .onTapGesture {
+                // 약속 수정하는 Popover 띄우기
+                isShowingPopover.toggle()
+            }
+            .popover(isPresented: $isShowingPopover) {
+                // EditPromisePopover에 약속 전달.
+                EditPromisePopover(promise: promise, isPresented: $isShowingPopover)
+            }
+        }
+    }
+}
+
+//struct PromiseCell_Previews: PreviewProvider {
+//    static var previews: some View {
+//        PromiseCell()
+//    }
+//}


### PR DESCRIPTION
### Motivation

- 약속을 합의하기 전에 수정이 가능해야 합니다. 
- LOFI를 따라서, 리스트의 수정 아이콘(세로 점 3개)을 눌러서 수정할 수 있어야 합니다. 

### Key Changes 

- **약속 셀의 수정하기 아이콘을 눌러 약속의 이름과 메모를 수정할 수 있습니다.**
- EditPromisePopover가 전달받은 약속을 수정할 수 있게 만들었어요. 
- List의 Item(약속) 별로 팝오버를 띄우기 위해, FilteredList에 있던 약속 아이템을 PromiseCell 파일로 따로 뺐어요. 
- FilteredList에서 PromiseCell를 호출하고, PromiseCell에서 EditPromisePopover를 호출하게 했어요.
- 작성한 코드에 주석을 달았어요.

### Tests 

- 약속 수정하기 팝오버에서 수정을 마치면 메인 화면에서 바로 렌더링 되는 거 확인했어요. 
- 앱 재시작 후 데이터 수정(CoreData 업데이트)이 제대로 되었는지 확인했어요.
