### PR TITLE
Feat[#47] : 탭 버튼별 뷰 연결

### DIFF
--- a/kko_okk/Views/BoardViews/ReportBoardView.swift
+++ b/kko_okk/Views/BoardViews/ReportBoardView.swift
@@ -9,7 +9,9 @@ import SwiftUI
 
 struct ReportBoardView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Spacer()
+        Text("Report Board View")
+        Spacer()
     }
 }
 

--- a/kko_okk/Views/BoardViews/SettingView.swift
+++ b/kko_okk/Views/BoardViews/SettingView.swift
@@ -8,13 +8,22 @@
 import SwiftUI
 
 struct SettingView: View {
+    @Binding var isShowingSettingView: Bool
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Spacer()
+        Button(action: {
+            isShowingSettingView.toggle()
+        }, label: {
+            Text("돌아가기")
+        })
+        Text("Setting View")
+        Spacer()
     }
 }
 
-struct SettingView_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingView()
-    }
-}
+//struct SettingView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        SettingView()
+//    }
+//}

--- a/kko_okk/Views/MainView.swift
+++ b/kko_okk/Views/MainView.swift
@@ -8,9 +8,16 @@
 import SwiftUI
 
 struct MainView: View {
+    @State var isShowingSettingView = false
+    
     var body: some View {
-        HeaderView()
-        SegmentView()
+        if isShowingSettingView {
+            SettingView(isShowingSettingView: $isShowingSettingView)
+        }
+        else {
+            HeaderView()
+            SegmentView(isPressedSettingButton: $isShowingSettingView)
+        }
     }
 }
 

--- a/kko_okk/Views/SegmentView.swift
+++ b/kko_okk/Views/SegmentView.swift
@@ -8,37 +8,80 @@
 import SwiftUI
 
 struct SegmentView: View {
+    @State private var isShowingTodoBoard = true
+    @State private var isShowingReportBoard = false
+    @Binding var isPressedSettingButton: Bool
+//    @State var isPressedSettingButton = false
+    
     var body: some View {
-        VStack{
+        VStack(alignment: .leading){
+            
             // Custom Tab Bar 만들기 (ex. 약속 만들기, 약속 리포트(이행률) 보기, 설정)
-            HStack{
-                Button(action: {
+                HStack{
                     
-                }, label: {
-                    Text("약속 만들기")
-                })
-                
-                Button(action: {
+                    Button(action: {
+                        
+                        isShowingTodoBoard.toggle()
+                        
+                        if (isShowingReportBoard) {
+                            isShowingReportBoard.toggle()
+                        }
+                        
+                    }, label: {
+                        Text("약속 만들기")
+                            .foregroundColor(isShowingTodoBoard ? .Kkookk.commonBlack : .Kkookk.unselectedTabGray)
+                            .font(Font.Kkookk.boardTabSelected)
+                        
+                    })
+                    .animation(.default, value: isShowingTodoBoard)
+                    .buttonStyle(.plain)
                     
-                }, label: {
-                    Text("이행률 보기")
-                })
-                Button(action: {
+                    Button(action: {
+                        
+                        isShowingReportBoard.toggle()
+                        
+                        if (isShowingTodoBoard) {
+                            isShowingTodoBoard.toggle()
+                        }
+
+                    }, label: {
+                        Text("이행률 보기")
+                            .foregroundColor(isShowingReportBoard ? .Kkookk.commonBlack : .Kkookk.unselectedTabGray)
+                            .font(Font.Kkookk.boardTabSelected)
+                    })
+                    .animation(.default, value: isShowingReportBoard)
+                    .buttonStyle(.plain)
                     
-                }, label: {
-                    Text("설정")
-                })
-            }.padding(10)
+                    Spacer()
+                    
+                    Button(action: {
+                        isPressedSettingButton.toggle()
+                    }, label: {
+                        Text("설정")
+                            .foregroundColor(.Kkookk.commonBlack)
+                            .font(Font.Kkookk.boardSettingButton)
+                    })
+                    
+                }.padding(15)
+            
+            // 임시 Divider
+            Divider()
             
             // Tab에 따라 보여줄 Board
-            TodoBoardView()
-        }.padding(10)
+            if (isShowingTodoBoard) {
+                TodoBoardView()
+            } else {
+                ReportBoardView()
+            }
+            
+        }.padding(26)
         
     }
 }
 
-struct BoardView_Previews: PreviewProvider {
-    static var previews: some View {
-        SegmentView()
-    }
-}
+//
+//struct BoardView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        SegmentView(isPressedSettingButton: $isPre)
+//    }
+//}


### PR DESCRIPTION
### Motivation

- 세그먼트뷰에 있는 버튼을 누르면 탭에 맞는 뷰들이 뜨도록 연결할 필요성을 느꼈습니다.

### Key Change

<img width="944" alt="스크린샷 2022-06-05 오후 9 06 07" src="https://user-images.githubusercontent.com/77262576/172049623-942027b6-
<img width="944" alt="스크린샷 2022-06-05 오후 9 06 13" src="https://user-images.githubusercontent.com/77262576/172049626-cd0a4cfa-33fd-4c5f-a5e1-e17bbd2e8fe4.png">
b416-423c-bb67-d2104183076c.png">
<img width="944" alt="스크린샷 2022-06-05 오후 9 06 21" src="https://user-images.githubusercontent.com/77262576/172049632-ef485caa-0de1-4030-8a01-bd4ce7012a8e.png">

- 누른 탭에 따라 색과 폰트가 바뀌도록 했습니다.
- settingView의 경우 기획 때 말했던 대로 헤더 뷰와 보드 뷰들을 가리는 방식으로 연결했습니다.

### To Reviewers

- 코드와 주석이 조금 지저분한데 다음 PR때 정리하겠습니다.
- Divider도 선택된 탭이 보이도록 보완하겠습니다.
