### PR TITLE
Header view/rolling banner view

### DIFF
--- a/kko_okk.xcodeproj/project.pbxproj
+++ b/kko_okk.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		22E9001F2848EE45000A82BE /* Promise+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E9001D2848EE45000A82BE /* Promise+CoreDataProperties.swift */; };
 		22E9005E2849D677000A82BE /* FilteredList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E9005D2849D677000A82BE /* FilteredList.swift */; };
 		70DAECB52849E0F5009AAB79 /* HeaderViewAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DAECB42849E0F5009AAB79 /* HeaderViewAssets.swift */; };
-		70DAECB9284B41A0009AAB79 /* RuyhaTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DAECB22849DF45009AAB79 /* RuyhaTestView.swift */; };
 		70DAECBD284E6209009AAB79 /* RollingBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DAECBC284E6209009AAB79 /* RollingBannerView.swift */; };
 		70DAECBF284E62D4009AAB79 /* BannerViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DAECBE284E62D4009AAB79 /* BannerViews.swift */; };
 		9D55B4052846289000AFD9C5 /* kko_okkApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D55B4042846289000AFD9C5 /* kko_okkApp.swift */; };
@@ -101,7 +100,6 @@
 		22E9001C2848EE45000A82BE /* Promise+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+CoreDataClass.swift"; sourceTree = "<group>"; };
 		22E9001D2848EE45000A82BE /* Promise+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		22E9005D2849D677000A82BE /* FilteredList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilteredList.swift; sourceTree = "<group>"; };
-		70DAECB22849DF45009AAB79 /* RuyhaTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuyhaTestView.swift; sourceTree = "<group>"; };
 		70DAECB42849E0F5009AAB79 /* HeaderViewAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderViewAssets.swift; sourceTree = "<group>"; };
 		70DAECBC284E6209009AAB79 /* RollingBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingBannerView.swift; sourceTree = "<group>"; };
 		70DAECBE284E62D4009AAB79 /* BannerViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerViews.swift; sourceTree = "<group>"; };
@@ -280,7 +278,6 @@
 			isa = PBXGroup;
 			children = (
 				A8C834A92847334400C65BE0 /* TitleView.swift */,
-				70DAECB22849DF45009AAB79 /* RuyhaTestView.swift */,
 				70DAECB42849E0F5009AAB79 /* HeaderViewAssets.swift */,
 				70DAECBC284E6209009AAB79 /* RollingBannerView.swift */,
 				70DAECBE284E62D4009AAB79 /* BannerViews.swift */,
@@ -532,7 +529,6 @@
 				F87E1F90284B2D5900AD05B3 /* Subject.swift in Sources */,
 				9DEB3A3128462AA10001959A /* TodoBoardView.swift in Sources */,
 				9D55B4072846289000AFD9C5 /* ContentView.swift in Sources */,
-				70DAECB9284B41A0009AAB79 /* RuyhaTestView.swift in Sources */,
 				70DAECBF284E62D4009AAB79 /* BannerViews.swift in Sources */,
 				70DAECB52849E0F5009AAB79 /* HeaderViewAssets.swift in Sources */,
 				A8C834A028471AA300C65BE0 /* SegmentView.swift in Sources */,

--- a/kko_okk.xcodeproj/project.pbxproj
+++ b/kko_okk.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		22E9005E2849D677000A82BE /* FilteredList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E9005D2849D677000A82BE /* FilteredList.swift */; };
 		70DAECB52849E0F5009AAB79 /* HeaderViewAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DAECB42849E0F5009AAB79 /* HeaderViewAssets.swift */; };
 		70DAECB9284B41A0009AAB79 /* RuyhaTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DAECB22849DF45009AAB79 /* RuyhaTestView.swift */; };
+		70DAECBD284E6209009AAB79 /* RollingBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DAECBC284E6209009AAB79 /* RollingBannerView.swift */; };
+		70DAECBF284E62D4009AAB79 /* BannerViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DAECBE284E62D4009AAB79 /* BannerViews.swift */; };
 		9D55B4052846289000AFD9C5 /* kko_okkApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D55B4042846289000AFD9C5 /* kko_okkApp.swift */; };
 		9D55B4072846289000AFD9C5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D55B4062846289000AFD9C5 /* ContentView.swift */; };
 		9D55B4092846289100AFD9C5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9D55B4082846289100AFD9C5 /* Assets.xcassets */; };
@@ -101,6 +103,8 @@
 		22E9005D2849D677000A82BE /* FilteredList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilteredList.swift; sourceTree = "<group>"; };
 		70DAECB22849DF45009AAB79 /* RuyhaTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuyhaTestView.swift; sourceTree = "<group>"; };
 		70DAECB42849E0F5009AAB79 /* HeaderViewAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderViewAssets.swift; sourceTree = "<group>"; };
+		70DAECBC284E6209009AAB79 /* RollingBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingBannerView.swift; sourceTree = "<group>"; };
+		70DAECBE284E62D4009AAB79 /* BannerViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerViews.swift; sourceTree = "<group>"; };
 		9D55B4012846289000AFD9C5 /* kko_okk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = kko_okk.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D55B4042846289000AFD9C5 /* kko_okkApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = kko_okkApp.swift; sourceTree = "<group>"; };
 		9D55B4062846289000AFD9C5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -278,6 +282,8 @@
 				A8C834A92847334400C65BE0 /* TitleView.swift */,
 				70DAECB22849DF45009AAB79 /* RuyhaTestView.swift */,
 				70DAECB42849E0F5009AAB79 /* HeaderViewAssets.swift */,
+				70DAECBC284E6209009AAB79 /* RollingBannerView.swift */,
+				70DAECBE284E62D4009AAB79 /* BannerViews.swift */,
 			);
 			path = HeaderViews;
 			sourceTree = "<group>";
@@ -527,12 +533,14 @@
 				9DEB3A3128462AA10001959A /* TodoBoardView.swift in Sources */,
 				9D55B4072846289000AFD9C5 /* ContentView.swift in Sources */,
 				70DAECB9284B41A0009AAB79 /* RuyhaTestView.swift in Sources */,
+				70DAECBF284E62D4009AAB79 /* BannerViews.swift in Sources */,
 				70DAECB52849E0F5009AAB79 /* HeaderViewAssets.swift in Sources */,
 				A8C834A028471AA300C65BE0 /* SegmentView.swift in Sources */,
 				22E9001F2848EE45000A82BE /* Promise+CoreDataProperties.swift in Sources */,
 				9D55B4052846289000AFD9C5 /* kko_okkApp.swift in Sources */,
 				A8C834C62848A37D00C65BE0 /* WeeklyReportView.swift in Sources */,
 				A8C834C82848A38C00C65BE0 /* MonthlyReportView.swift in Sources */,
+				70DAECBD284E6209009AAB79 /* RollingBannerView.swift in Sources */,
 				A8C8349E28471A7D00C65BE0 /* HeaderView.swift in Sources */,
 				22E9001E2848EE45000A82BE /* Promise+CoreDataClass.swift in Sources */,
 				A8C834C42848A37400C65BE0 /* DailyReportView.swift in Sources */,

--- a/kko_okk/Views/HeaderView.swift
+++ b/kko_okk/Views/HeaderView.swift
@@ -29,7 +29,7 @@ struct HeaderView: View {
                     .frame(width: 965, height: 180, alignment: .leading)
                     .padding(.trailing,25)
                 
-                RuyhaTestView()
+                RollingBannerView()
                     .cornerRadius(HVA.cornerRadius)
                     .frame(width: 300, height: 145, alignment: .bottomTrailing)
                     .padding(.top,35)

--- a/kko_okk/Views/HeaderViews/BannerViews.swift
+++ b/kko_okk/Views/HeaderViews/BannerViews.swift
@@ -1,0 +1,63 @@
+//
+//  BannerViews.swift
+//  kko_okk
+//
+//  Created by Ruyha on 2022/06/07.
+//
+
+import SwiftUI
+
+
+enum BannerViews : CaseIterable{
+    case view1
+    case view2
+    case view3
+}
+
+class RollingBannerController{
+    @ViewBuilder
+    func pageing(view:BannerViews) -> some View{
+        switch view{
+        case .view1:
+            BannerView_1()
+        case .view2:
+            BannerView_2()
+        case .view3:
+            BannerView_3()
+        }
+    }
+}
+
+
+//롤링배너에 들어갈 View들 입니다.
+//아직 정해진것이 없어서 가데이터로 넣어 놨습니다.
+
+struct BannerView_1: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+
+struct BannerView_2: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+
+struct BannerView_3: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+
+
+
+
+//struct BannerViews_Previews: PreviewProvider {
+//    static var previews: some View {
+//        BannerViews()
+//    }
+//}

--- a/kko_okk/Views/HeaderViews/BannerViews.swift
+++ b/kko_okk/Views/HeaderViews/BannerViews.swift
@@ -34,22 +34,30 @@ class RollingBannerController{
 
 struct BannerView_1: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ZStack{
+            Color.blue
+            Text("1")
+        }
     }
 }
 
 
 struct BannerView_2: View {
     var body: some View {
-        Text("Hello, World!")
+        ZStack{
+            Color.red
+            Text("2")
+        }
     }
 }
 
 
 struct BannerView_3: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-    }
+        ZStack{
+            Color.green
+            Text("3")
+        }    }
 }
 
 

--- a/kko_okk/Views/HeaderViews/BannerViews.swift
+++ b/kko_okk/Views/HeaderViews/BannerViews.swift
@@ -31,7 +31,6 @@ class RollingBannerController{
 
 //롤링배너에 들어갈 View들 입니다.
 //아직 정해진것이 없어서 가데이터로 넣어 놨습니다.
-
 struct BannerView_1: View {
     var body: some View {
         ZStack{

--- a/kko_okk/Views/HeaderViews/RollingBannerView.swift
+++ b/kko_okk/Views/HeaderViews/RollingBannerView.swift
@@ -1,0 +1,26 @@
+//
+//  RollingBannerView.swift
+//  kko_okk
+//
+//  Created by Ruyha on 2022/06/07.
+//
+
+import SwiftUI
+
+struct RollingBannerView: View {
+    @State var selectedItem = 0
+
+    var body: some View {
+        TabView(selection: $selectedItem){
+            
+        }
+        
+        
+    }
+}
+
+struct RollingBannerView_Previews: PreviewProvider {
+    static var previews: some View {
+        RollingBannerView()
+    }
+}

--- a/kko_okk/Views/HeaderViews/RollingBannerView.swift
+++ b/kko_okk/Views/HeaderViews/RollingBannerView.swift
@@ -9,13 +9,37 @@ import SwiftUI
 
 struct RollingBannerView: View {
     @State var selectedItem = 0
-
+    var RBC = RollingBannerController()
+    let RBTime : Double = 5
+    // RollingBanner Time 롤링베너가 몇 초에 한번씩 변경할지 정합니다.
     var body: some View {
         TabView(selection: $selectedItem){
-            
+            ForEach((0...BannerViews.allCases.count - 1),id: \.self) {
+                RBC.pageing(view: BannerViews.allCases[$0])
+            }
+        }//TabView
+        .tabViewStyle(PageTabViewStyle())
+        .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
+        .onAppear{
+            playRollingBanner()
         }
         
         
+    }
+}
+
+extension RollingBannerView{
+    func playRollingBanner(){
+        Timer.scheduledTimer(withTimeInterval: RBTime, repeats: true){(Timer) in
+            withAnimation(.easeInOut(duration: 1)){
+                // 하단 주석 1참고
+                guard selectedItem == BannerViews.allCases.count - 1 else {
+                    selectedItem = selectedItem + 1
+                    return
+                }
+                selectedItem = 0
+            }
+        }
     }
 }
 
@@ -24,3 +48,23 @@ struct RollingBannerView_Previews: PreviewProvider {
         RollingBannerView()
     }
 }
+
+/*
+ 주석1
+  if selectedItem == BannerViews.allCases.count - 1{
+        selectedItem = 0
+    }else{
+    selectedItem = selectedItem + 1
+    }
+ 이 코드와
+ 
+ guard selectedItem == BannerViews.allCases.count - 1 else {
+     selectedItem = selectedItem + 1
+     return
+ }
+ selectedItem = 0
+ 이 코드는 동일하게 동작합니다.
+ 
+ 스위프트에서는 guard (거짓일떄 먼저 실행)을 많이 사용해 넣어 봤습니다.
+ 
+ */

--- a/kko_okk/Views/HeaderViews/RollingBannerView.swift
+++ b/kko_okk/Views/HeaderViews/RollingBannerView.swift
@@ -19,15 +19,18 @@ struct RollingBannerView: View {
             }
         }//TabView
         .tabViewStyle(PageTabViewStyle())
-        .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
+        .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .interactive))
         .onAppear{
             playRollingBanner()
         }
         
         
     }
+    
 }
 
+// View에는 View에 해당하는 코드만 깔끔하게 들어가길 바라며
+// 사용되는 extension을 사용했습니다.
 extension RollingBannerView{
     func playRollingBanner(){
         Timer.scheduledTimer(withTimeInterval: RBTime, repeats: true){(Timer) in
@@ -41,6 +44,14 @@ extension RollingBannerView{
             }
         }
     }
+    
+    //롤링베너 Indicator의 사이즈를 변경하기위해 제작
+    //색상까지는 변경 가능하나 사이즈는 변경 불가.
+    func setupAppearance() {
+        UIPageControl.appearance().currentPageIndicatorTintColor = .black
+        UIPageControl.appearance().pageIndicatorTintColor = UIColor.black.withAlphaComponent(0.2)
+        //사이즈 변경은 어렵네요..
+    }
 }
 
 struct RollingBannerView_Previews: PreviewProvider {
@@ -51,16 +62,16 @@ struct RollingBannerView_Previews: PreviewProvider {
 
 /*
  주석1
-  if selectedItem == BannerViews.allCases.count - 1{
-        selectedItem = 0
-    }else{
-    selectedItem = selectedItem + 1
-    }
+ if selectedItem == BannerViews.allCases.count - 1{
+ selectedItem = 0
+ }else{
+ selectedItem = selectedItem + 1
+ }
  이 코드와
  
  guard selectedItem == BannerViews.allCases.count - 1 else {
-     selectedItem = selectedItem + 1
-     return
+ selectedItem = selectedItem + 1
+ return
  }
  selectedItem = 0
  이 코드는 동일하게 동작합니다.


### PR DESCRIPTION
Motivation
롤링베너 기능이 생성되었습니다.

Key Change
무한 스크롤 처럼 보이게 구현할 필요는 없어서 마지막 페이지에 도달하면
처음 페이지로 이동합니다.

인디케이터 (...)는 SwiftUI로 구현시
사이즈 조절이 불가능해 배경만 지웠습니다.

조금 더 완벽한 롤링 배너는 사용자가 직접 스크롤시 스크롤 시간이 초기화 되어야 하나
그것까지 구현 하지는 않았습니다.

HeaderView와 TileView를 정비하면서 같이 픽셀 조절예정입니다.

To Reviewers
View안에 사용하는 함수를
extension으로 빼서 만들면 view가 조금 더 깔끔해 지는것 같습니다.