### PR TITLE
Fix[#75]: Popover에서 요일 버튼 순서가 랜덤으로 등장하는 문제 해결

### DIFF
--- a/kko_okk.xcodeproj/project.pbxproj
+++ b/kko_okk.xcodeproj/project.pbxproj
@@ -75,6 +75,9 @@
 		F87E1F92284B2FA700AD05B3 /* EditPromisePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87E1F91284B2FA700AD05B3 /* EditPromisePopover.swift */; };
 		F889B519284C797B006DFEFC /* PromiseCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F889B518284C797B006DFEFC /* PromiseCell.swift */; };
 		F89CAB772849D761006C72BD /* AddPromisePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89CAB762849D761006C72BD /* AddPromisePopover.swift */; };
+		F8A424B828532486007123E8 /* EditContentsOfPromiseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A424B728532486007123E8 /* EditContentsOfPromiseView.swift */; };
+		F8A424BB2853295F007123E8 /* PopoverViewAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A424BA2853295F007123E8 /* PopoverViewAssets.swift */; };
+		F8A424BD28532C15007123E8 /* EditRepeatingDaysOfPromiseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A424BC28532C15007123E8 /* EditRepeatingDaysOfPromiseView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -145,6 +148,9 @@
 		F87E1F91284B2FA700AD05B3 /* EditPromisePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPromisePopover.swift; sourceTree = "<group>"; };
 		F889B518284C797B006DFEFC /* PromiseCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseCell.swift; sourceTree = "<group>"; };
 		F89CAB762849D761006C72BD /* AddPromisePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPromisePopover.swift; sourceTree = "<group>"; };
+		F8A424B728532486007123E8 /* EditContentsOfPromiseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditContentsOfPromiseView.swift; sourceTree = "<group>"; };
+		F8A424BA2853295F007123E8 /* PopoverViewAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverViewAssets.swift; sourceTree = "<group>"; };
+		F8A424BC28532C15007123E8 /* EditRepeatingDaysOfPromiseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRepeatingDaysOfPromiseView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -277,6 +283,7 @@
 		9DEB3A22284629E90001959A /* TodoTab */ = {
 			isa = PBXGroup;
 			children = (
+				F8A424B928532494007123E8 /* PromisePopoverElements */,
 				9DEB3A20284629E30001959A /* ParentWishView.swift */,
 				9DEB3A2328462A100001959A /* ChildWishView.swift */,
 				9DEB3A2528462A240001959A /* ContractView.swift */,
@@ -346,6 +353,16 @@
 				9D55B4082846289100AFD9C5 /* Assets.xcassets */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		F8A424B928532494007123E8 /* PromisePopoverElements */ = {
+			isa = PBXGroup;
+			children = (
+				F8A424B728532486007123E8 /* EditContentsOfPromiseView.swift */,
+				F8A424BC28532C15007123E8 /* EditRepeatingDaysOfPromiseView.swift */,
+				F8A424BA2853295F007123E8 /* PopoverViewAssets.swift */,
+			);
+			path = PromisePopoverElements;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -515,11 +532,13 @@
 				A8C834A828471D0400C65BE0 /* Size.swift in Sources */,
 				9DEB3A21284629E30001959A /* ParentWishView.swift in Sources */,
 				9DEB3A2828462A4B0001959A /* ButtonForContract.swift in Sources */,
+				F8A424B828532486007123E8 /* EditContentsOfPromiseView.swift in Sources */,
 				F87E1F92284B2FA700AD05B3 /* EditPromisePopover.swift in Sources */,
 				221CC2C428479F74009F4851 /* TipModel.swift in Sources */,
 				F889B519284C797B006DFEFC /* PromiseCell.swift in Sources */,
 				22E9005E2849D677000A82BE /* FilteredList.swift in Sources */,
 				9D55B40E2846289100AFD9C5 /* Persistence.swift in Sources */,
+				F8A424BD28532C15007123E8 /* EditRepeatingDaysOfPromiseView.swift in Sources */,
 				A8C834C22848A34E00C65BE0 /* SettingView.swift in Sources */,
 				7080B195285320A400A7BD44 /* BannerViews.swift in Sources */,
 				9D55B4112846289100AFD9C5 /* kko_okk.xcdatamodeld in Sources */,
@@ -537,6 +556,7 @@
 				A8C8349E28471A7D00C65BE0 /* HeaderView.swift in Sources */,
 				22E9001E2848EE45000A82BE /* Promise+CoreDataClass.swift in Sources */,
 				A8C834C02848A34400C65BE0 /* ReportBoardView.swift in Sources */,
+				F8A424BB2853295F007123E8 /* PopoverViewAssets.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/kko_okk/Views/BoardViews/TodoTab/AddPromisePopover.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/AddPromisePopover.swift
@@ -22,13 +22,7 @@ struct AddPromisePopover: View {
     @State var memo: String = ""
     
     // 반복 요일
-    @State var repeatedDaysOfWeekDict: [String: Bool] = ["월요일": false,
-                                                         "화요일": false,
-                                                         "수요일": false,
-                                                         "목요일": false,
-                                                         "금요일": false,
-                                                         "토요일": false,
-                                                         "일요일": false]
+    @State var isRepeating: [Bool] = [false, false, false, false, false, false, false]
     
     var body: some View {
         VStack {
@@ -70,8 +64,11 @@ struct AddPromisePopover: View {
             // 약속 제목과 메모를 수정하는 부분
             EditContentsOfPromiseView(name: $name, memo: $memo)
             
+            //            // 반복 날짜 선택 버튼
+            //            EditRepeatingDaysOfPromiseView(repeatedDaysOfWeekDict: $repeatedDaysOfWeekDict, subject: subject)
+            
             // 반복 날짜 선택 버튼
-            EditRepeatingDaysOfPromiseView(repeatedDaysOfWeekDict: $repeatedDaysOfWeekDict, subject: subject)
+            EditRepeatingDaysOfPromiseView(isRepeating: $isRepeating, subject: subject)
         }
         .padding()
         .frame(width: 800, height: 500)
@@ -106,13 +103,13 @@ extension AddPromisePopover {
             }
             
             // 반복 요일 입력. 초기값은 전부 false.
-            promise.isRepeatedOnMonday = repeatedDaysOfWeekDict["월요일"] ?? false
-            promise.isRepeatedOnTuesday = repeatedDaysOfWeekDict["화요일"] ?? false
-            promise.isRepeatedOnWednesday = repeatedDaysOfWeekDict["수요일"] ?? false
-            promise.isRepeatedOnThursday = repeatedDaysOfWeekDict["목요일"] ?? false
-            promise.isRepeatedOnFriday = repeatedDaysOfWeekDict["금요일"] ?? false
-            promise.isRepeatedOnSaturday = repeatedDaysOfWeekDict["토요일"] ?? false
-            promise.isRepeatedOnSunday = repeatedDaysOfWeekDict["일요일"] ?? false
+            promise.isRepeatedOnMonday = isRepeating[0]
+            promise.isRepeatedOnTuesday = isRepeating[1]
+            promise.isRepeatedOnWednesday = isRepeating[2]
+            promise.isRepeatedOnThursday = isRepeating[3]
+            promise.isRepeatedOnFriday = isRepeating[4]
+            promise.isRepeatedOnSaturday = isRepeating[5]
+            promise.isRepeatedOnSunday = isRepeating[6]
             
             // 데이터 저장
             do {

--- a/kko_okk/Views/BoardViews/TodoTab/AddPromisePopover.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/AddPromisePopover.swift
@@ -15,7 +15,7 @@ struct AddPromisePopover: View {
     @Environment(\.managedObjectContext) private var viewContext
     
     // popover 띄우고 닫을 변수
-    @Binding var isShowingPopover: Bool
+    @Binding var isPresented: Bool
     
     // 완료 버튼을 누르기 전까지 임시 값을 저장하는 변수
     @State var name: String = ""
@@ -33,9 +33,9 @@ struct AddPromisePopover: View {
     var body: some View {
         VStack {
             HStack {
+                // Popover 닫기
                 Button {
-                    // Popover 띄우기
-                    isShowingPopover.toggle()
+                    isPresented.toggle()
                 } label: {
                     Text("취소")
                 }
@@ -57,7 +57,7 @@ struct AddPromisePopover: View {
                     addPromise()
                     
                     // Popover 닫기
-                    isShowingPopover.toggle()
+                    isPresented.toggle()
                 } label: {
                     Text("완료")
                 }
@@ -65,73 +65,10 @@ struct AddPromisePopover: View {
             .padding()
             .font(.title3)
             
-            HStack {
-                Text("할 일 정하기")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                Spacer()
-            }
-            
-            ZStack {
-                // name, memo 텍스트필드를 붙어있는 것처럼 만들기 위한 사각형
-                RoundedRectangle(cornerRadius: 15)
-                    .frame(width: 760, height: 200)
-                    .foregroundColor(.white)
-                
-                VStack {
-                    // name 수정하는 영역
-                    TextField("할 일", text: $name)
-                        .background(.white)
-                        .cornerRadius(15)
-                        .padding(.horizontal, 13)
-                    
-                    Divider()
-                        .padding(.horizontal, 8)
-                        .foregroundColor(.gray)
-                    
-                    // memo 수정하는 영역
-                    ZStack(alignment: .topLeading) {
-                        TextEditor(text: $memo)
-                            .frame(width: 760, height: 130)
-                            .cornerRadius(15)
-                            .padding(.horizontal, 8)
-                        
-                        // placeholder
-                        if memo.isEmpty {
-                            Text("메모 추가하기")
-                                .cornerRadius(15)
-                                .padding(.horizontal, 15)
-                                .padding(.top, 10)
-                                .foregroundColor(Color.Kkookk.unselectedTabGray)
-                        }
-                    }
-                }
-            }
+            EditContentsOfPromiseView(name: $name, memo: $memo)
             
             // 반복 날짜 선택 버튼
-            HStack {
-                Text("반복")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                Spacer()
-            }
-            
-            HStack {
-                ForEach(Array(repeatedDaysOfWeekDict.keys), id: \.self) { key in
-                    Button(action: {
-                        repeatedDaysOfWeekDict[key]?.toggle()
-                    }, label: {
-                        ZStack {
-                            Rectangle()
-                                .frame(width: 100, height: 40)
-                                .foregroundColor(repeatedDaysOfWeekDict[key] ?? false ? getPointColor(subject: subject) : Color.Kkookk.unselectedTabGray)
-                                .cornerRadius(10, antialiased:  true)
-                            Text(key)
-                                .foregroundColor(repeatedDaysOfWeekDict[key] ?? false ? Color.Kkookk.commonWhite : Color.Kkookk.commonBlack)
-                        }
-                    })
-                }
-            }
+            EditRepeatingDaysOfPromiseView(repeatedDaysOfWeekDict: $repeatedDaysOfWeekDict, subject: subject)
         }
         .padding()
         .frame(width: 800, height: 500)
@@ -142,6 +79,7 @@ struct AddPromisePopover: View {
     private func addPromise() {
         withAnimation {
             let promise = Promise(context: viewContext)
+            
             promise.id = UUID()
             promise.name = name
             promise.memo = memo
@@ -180,6 +118,7 @@ struct AddPromisePopover: View {
         }
     }
 }
+
 
 //struct AddWishPopover_Previews: PreviewProvider {
 //    static var previews: some View {

--- a/kko_okk/Views/BoardViews/TodoTab/AddPromisePopover.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/AddPromisePopover.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct AddPromisePopover: View {
-    // Subject enum이 .parent인지 .child인지에 따라 뷰의 기능이 달라짐.
+    // Subject enum이 .parent인지 .child인지에 따라 뷰의 포인트 컬러와 subject attribute 기능이 달라짐.
     var subject: Subject
     
     // viewContext 받아오기
@@ -32,6 +32,8 @@ struct AddPromisePopover: View {
     
     var body: some View {
         VStack {
+            // 팝오버 헤더.
+            // 취소, 타이틀, 완료 버튼(약속 생성 및 CoreData 업데이트)으로 구성.
             HStack {
                 // Popover 닫기
                 Button {
@@ -65,6 +67,7 @@ struct AddPromisePopover: View {
             .padding()
             .font(.title3)
             
+            // 약속 제목과 메모를 수정하는 부분
             EditContentsOfPromiseView(name: $name, memo: $memo)
             
             // 반복 날짜 선택 버튼

--- a/kko_okk/Views/BoardViews/TodoTab/AddPromisePopover.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/AddPromisePopover.swift
@@ -77,6 +77,9 @@ struct AddPromisePopover: View {
         .frame(width: 800, height: 500)
         .background(.bar)
     }
+}
+
+extension AddPromisePopover {
     
     // name, memo 변수에 저장되어 있는 임시값으로 CoreData에 새로운 Promise를 생성, 저장.
     private func addPromise() {

--- a/kko_okk/Views/BoardViews/TodoTab/ChildWishView.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ChildWishView.swift
@@ -31,7 +31,7 @@ struct ChildWishView: View {
                         .frame(width: 30, height: 30)
                 }
                 .popover(isPresented: $isShowingPopover) {
-                    AddPromisePopover(subject: .child, isShowingPopover: $isShowingPopover)
+                    AddPromisePopover(subject: .child, isPresented: $isShowingPopover)
                 }
             }
             .padding(.trailing, 10)

--- a/kko_okk/Views/BoardViews/TodoTab/EditPromisePopover.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/EditPromisePopover.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct EditPromisePopover: View {
-    // Subject enum이 .parent인지 .child인지에 따라 뷰의 기능이 달라짐.
+    // Subject enum이 .parent인지 .child인지에 따라 뷰의 포인트 컬러와 subject attribute 기능이 달라짐.
     var subject: Subject
     
     // PromiseCell로부터 약속 받아오기
@@ -35,6 +35,8 @@ struct EditPromisePopover: View {
     
     var body: some View {
         VStack {
+            // 팝오버 헤더.
+            // 취소, 타이틀, 완료 버튼(기존 약속 내용 수정 및 CoreData 업데이트)으로 구성.
             HStack {
                 // Popover 닫기
                 Button {
@@ -68,6 +70,7 @@ struct EditPromisePopover: View {
             .padding()
             .font(.title3)
             
+            // 약속 제목과 메모를 수정하는 부분
             EditContentsOfPromiseView(name: $name, memo: $memo)
             
             // 반복 날짜 선택 버튼

--- a/kko_okk/Views/BoardViews/TodoTab/EditPromisePopover.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/EditPromisePopover.swift
@@ -25,13 +25,7 @@ struct EditPromisePopover: View {
     @State var memo: String = ""
     
     // 반복 요일
-    @State var repeatedDaysOfWeekDict: [String: Bool] = ["월요일": false,
-                                                         "화요일": false,
-                                                         "수요일": false,
-                                                         "목요일": false,
-                                                         "금요일": false,
-                                                         "토요일": false,
-                                                         "일요일": false]
+    @State var isRepeating: [Bool] = [false, false, false, false, false, false, false]
     
     var body: some View {
         VStack {
@@ -74,7 +68,7 @@ struct EditPromisePopover: View {
             EditContentsOfPromiseView(name: $name, memo: $memo)
             
             // 반복 날짜 선택 버튼
-            EditRepeatingDaysOfPromiseView(repeatedDaysOfWeekDict: $repeatedDaysOfWeekDict, subject: subject)
+            EditRepeatingDaysOfPromiseView(isRepeating: $isRepeating, subject: subject)
         }
         .onAppear() {
             // 뷰를 그릴 때, 받아온 약속의 name, memo 값을 임시값에 저장
@@ -82,13 +76,13 @@ struct EditPromisePopover: View {
             memo = promise.memo ?? ""
             
             // CoreData의 요일값 불러오기.
-            repeatedDaysOfWeekDict["월요일"] = promise.isRepeatedOnMonday
-            repeatedDaysOfWeekDict["화요일"] = promise.isRepeatedOnTuesday
-            repeatedDaysOfWeekDict["수요일"] = promise.isRepeatedOnWednesday
-            repeatedDaysOfWeekDict["목요일"] = promise.isRepeatedOnThursday
-            repeatedDaysOfWeekDict["금요일"] = promise.isRepeatedOnFriday
-            repeatedDaysOfWeekDict["토요일"] = promise.isRepeatedOnSaturday
-            repeatedDaysOfWeekDict["일요일"] = promise.isRepeatedOnSunday
+            isRepeating[0] = promise.isRepeatedOnMonday
+            isRepeating[1] = promise.isRepeatedOnTuesday
+            isRepeating[2] = promise.isRepeatedOnWednesday
+            isRepeating[3] = promise.isRepeatedOnThursday
+            isRepeating[4] = promise.isRepeatedOnFriday
+            isRepeating[5] = promise.isRepeatedOnSaturday
+            isRepeating[6] = promise.isRepeatedOnSunday
         }
         .padding()
         .frame(width: 800, height: 500)
@@ -105,13 +99,13 @@ extension EditPromisePopover {
             promise.memo = memo
             
             // 반복 요일 변경.
-            promise.isRepeatedOnMonday = repeatedDaysOfWeekDict["월요일"] ?? false
-            promise.isRepeatedOnTuesday = repeatedDaysOfWeekDict["화요일"] ?? false
-            promise.isRepeatedOnWednesday = repeatedDaysOfWeekDict["수요일"] ?? false
-            promise.isRepeatedOnThursday = repeatedDaysOfWeekDict["목요일"] ?? false
-            promise.isRepeatedOnFriday = repeatedDaysOfWeekDict["금요일"] ?? false
-            promise.isRepeatedOnSaturday = repeatedDaysOfWeekDict["토요일"] ?? false
-            promise.isRepeatedOnSunday = repeatedDaysOfWeekDict["일요일"] ?? false
+            promise.isRepeatedOnMonday = isRepeating[0]
+            promise.isRepeatedOnTuesday = isRepeating[1]
+            promise.isRepeatedOnWednesday = isRepeating[2]
+            promise.isRepeatedOnThursday = isRepeating[3]
+            promise.isRepeatedOnFriday = isRepeating[4]
+            promise.isRepeatedOnSaturday = isRepeating[5]
+            promise.isRepeatedOnSunday = isRepeating[6]
 
             // CoreData에 저장하기
             do {

--- a/kko_okk/Views/BoardViews/TodoTab/EditPromisePopover.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/EditPromisePopover.swift
@@ -36,8 +36,8 @@ struct EditPromisePopover: View {
     var body: some View {
         VStack {
             HStack {
+                // Popover 닫기
                 Button {
-                    // Popover 열기
                     isPresented.toggle()
                 } label: {
                     Text("취소")
@@ -45,12 +45,18 @@ struct EditPromisePopover: View {
                 
                 Spacer()
                 
-                Text("약속 수정하기")
+                // 입력받은 enum 값에 따라 popover 상단 바의 제목을 바꿔주기.
+                switch subject {
+                case .parent:
+                    Text("부모의 약속 만들기")
+                case .child:
+                    Text("아이의 약속 만들기")
+                }
                 
                 Spacer()
                 
                 Button {
-                    // name, memo 변수에 저장되어 있는 임시값을 CoreData에 업데이트
+                    // name, memo 변수에 저장되어 있는 임시값으로 CoreData에 새로운 Promise를 생성, 저장.
                     updatePromise(promise: promise)
                     
                     // Popover 닫기
@@ -62,75 +68,10 @@ struct EditPromisePopover: View {
             .padding()
             .font(.title3)
             
-            HStack {
-                Text("할 일 정하기")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                Spacer()
-            }
-            
-            ZStack {
-                // name, memo 텍스트필드를 붙어있는 것처럼 만들기 위한 사각형
-                RoundedRectangle(cornerRadius: 15)
-                    .frame(width: 760, height: 200)
-                    .foregroundColor(.white)
-                
-                VStack {
-                    // name 수정하는 영역
-                    TextField("할 일", text: $name)
-                        .background(.white)
-                        .cornerRadius(15)
-                        .padding(.horizontal, 13)
-                    
-                    Divider()
-                        .padding(.horizontal, 8)
-                        .foregroundColor(.gray)
-                    
-                    // memo 수정하는 영역
-                    ZStack(alignment: .leading) {
-                        TextEditor(text: $memo)
-                            .frame(width: 760, height: 130)
-                            .cornerRadius(15)
-                            .padding(.horizontal, 8)
-                        
-                        // placeholder
-                        if memo.isEmpty {
-                            Text("memo")
-                                .frame(width: 760, height: 130)
-                                .cornerRadius(15)
-                                .padding(.horizontal, 15)
-                                .padding(.top, 10)
-                                .foregroundColor(Color.Kkookk.unselectedTabGray)
-                        }
-                    }
-                }
-            }
+            EditContentsOfPromiseView(name: $name, memo: $memo)
             
             // 반복 날짜 선택 버튼
-            HStack {
-                Text("반복")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                Spacer()
-            }
-            
-            HStack {
-                ForEach(Array(repeatedDaysOfWeekDict.keys), id: \.self) { key in
-                    Button(action: {
-                        repeatedDaysOfWeekDict[key]?.toggle()
-                    }, label: {
-                        ZStack {
-                            Rectangle()
-                                .frame(width: 100, height: 40)
-                                .foregroundColor(repeatedDaysOfWeekDict[key] ?? false ? getPointColor(subject: subject) : Color.Kkookk.unselectedTabGray)
-                                .cornerRadius(10, antialiased:  true)
-                            Text(key)
-                                .foregroundColor(repeatedDaysOfWeekDict[key] ?? false ? Color.Kkookk.commonWhite : Color.Kkookk.commonBlack)
-                            
-                        }
-                    })
-                }
-            }
+            EditRepeatingDaysOfPromiseView(repeatedDaysOfWeekDict: $repeatedDaysOfWeekDict, subject: subject)
         }
         .onAppear() {
             // 뷰를 그릴 때, 받아온 약속의 name, memo 값을 임시값에 저장

--- a/kko_okk/Views/BoardViews/TodoTab/EditPromisePopover.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/EditPromisePopover.swift
@@ -94,6 +94,9 @@ struct EditPromisePopover: View {
         .frame(width: 800, height: 500)
         .background(.bar)
     }
+}
+
+extension EditPromisePopover {
     
     // name, memo 변수에 저장되어 있는 임시값을 CoreData에 업데이트.
     private func updatePromise(promise: Promise) {

--- a/kko_okk/Views/BoardViews/TodoTab/ParentWishView.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ParentWishView.swift
@@ -31,7 +31,7 @@ struct ParentWishView: View {
                         .frame(width: 30, height: 30)
                 }
                 .popover(isPresented: $isShowingPopover) {
-                    AddPromisePopover(subject: .parent, isShowingPopover: $isShowingPopover)
+                    AddPromisePopover(subject: .parent, isPresented: $isShowingPopover)
                 }
             }
             .padding(.trailing, 10)

--- a/kko_okk/Views/BoardViews/TodoTab/PromisePopoverElements/EditContentsOfPromiseView.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/PromisePopoverElements/EditContentsOfPromiseView.swift
@@ -8,11 +8,13 @@
 import SwiftUI
 
 struct EditContentsOfPromiseView: View {
+    // 약속 제목과 이름을 받아오는 부분.
     @Binding var name: String
     @Binding var memo: String
     
     var body: some View {
         VStack {
+            // 제목, 내용 수정 타이틀
             HStack {
                 Text("할 일 정하기")
                     .font(.largeTitle)

--- a/kko_okk/Views/BoardViews/TodoTab/PromisePopoverElements/EditContentsOfPromiseView.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/PromisePopoverElements/EditContentsOfPromiseView.swift
@@ -1,0 +1,66 @@
+//
+//  PromisePopoverElements.swift
+//  kko_okk
+//
+//  Created by 임성균 on 2022/06/10.
+//
+
+import SwiftUI
+
+struct EditContentsOfPromiseView: View {
+    @Binding var name: String
+    @Binding var memo: String
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Text("할 일 정하기")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                Spacer()
+            }
+            
+            ZStack {
+                // name, memo 텍스트필드를 붙어있는 것처럼 만들기 위한 사각형
+                RoundedRectangle(cornerRadius: 15)
+                    .frame(width: 760, height: 200)
+                    .foregroundColor(.white)
+                
+                VStack {
+                    // name 수정하는 영역
+                    TextField("할 일", text: $name)
+                        .background(.white)
+                        .cornerRadius(15)
+                        .padding(.horizontal, 13)
+                    
+                    Divider()
+                        .padding(.horizontal, 8)
+                        .foregroundColor(.gray)
+                    
+                    // memo 수정하는 영역
+                    ZStack(alignment: .topLeading) {
+                        TextEditor(text: $memo)
+                            .frame(width: 760, height: 130)
+                            .cornerRadius(15)
+                            .padding(.horizontal, 8)
+                        
+                        // placeholder
+                        if memo.isEmpty {
+                            Text("메모 추가하기")
+                                .cornerRadius(15)
+                                .padding(.horizontal, 15)
+                                .padding(.top, 10)
+                                .foregroundColor(Color.Kkookk.unselectedTabGray)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+//struct EditNameAndMemoOfPromiseView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        EditNameAndMemoOfPromiseView()
+//    }
+//}

--- a/kko_okk/Views/BoardViews/TodoTab/PromisePopoverElements/EditRepeatingDaysOfPromiseView.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/PromisePopoverElements/EditRepeatingDaysOfPromiseView.swift
@@ -1,0 +1,48 @@
+//
+//  EditRepeatingDaysOfPromiseView.swift
+//  kko_okk
+//
+//  Created by 임성균 on 2022/06/10.
+//
+
+import SwiftUI
+
+struct EditRepeatingDaysOfPromiseView: View {
+    @Binding var repeatedDaysOfWeekDict: [String: Bool]
+    
+    var subject: Subject
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Text("반복")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                Spacer()
+            }
+            
+            HStack {
+                ForEach(Array(repeatedDaysOfWeekDict.keys), id: \.self) { key in
+                    Button(action: {
+                        repeatedDaysOfWeekDict[key]?.toggle()
+                    }, label: {
+                        ZStack {
+                            Rectangle()
+                                .frame(width: 100, height: 40)
+                                .foregroundColor(repeatedDaysOfWeekDict[key] ?? false ? getPointColor(subject: subject) : Color.Kkookk.unselectedTabGray)
+                                .cornerRadius(10, antialiased:  true)
+                            Text(key)
+                                .foregroundColor(repeatedDaysOfWeekDict[key] ?? false ? Color.Kkookk.commonWhite : Color.Kkookk.commonBlack)
+                        }
+                    })
+                }
+            }
+        }
+    }
+}
+
+//struct EditRepeatingDaysOfPromiseView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        EditRepeatingDaysOfPromiseView()
+//    }
+//}

--- a/kko_okk/Views/BoardViews/TodoTab/PromisePopoverElements/EditRepeatingDaysOfPromiseView.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/PromisePopoverElements/EditRepeatingDaysOfPromiseView.swift
@@ -8,12 +8,15 @@
 import SwiftUI
 
 struct EditRepeatingDaysOfPromiseView: View {
+    // 임시 날짜 데이터 받아오기
     @Binding var repeatedDaysOfWeekDict: [String: Bool]
     
+    // 날짜가 선택되었을 때 버튼의 색을 결정하기 위해 subject 값을 받아오기
     var subject: Subject
     
     var body: some View {
         VStack {
+            // 제목, 내용 수정 타이틀
             HStack {
                 Text("반복")
                     .font(.largeTitle)
@@ -21,6 +24,7 @@ struct EditRepeatingDaysOfPromiseView: View {
                 Spacer()
             }
             
+            // 반복 날짜 선택 버튼
             HStack {
                 ForEach(Array(repeatedDaysOfWeekDict.keys), id: \.self) { key in
                     Button(action: {

--- a/kko_okk/Views/BoardViews/TodoTab/PromisePopoverElements/EditRepeatingDaysOfPromiseView.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/PromisePopoverElements/EditRepeatingDaysOfPromiseView.swift
@@ -9,7 +9,10 @@ import SwiftUI
 
 struct EditRepeatingDaysOfPromiseView: View {
     // 임시 날짜 데이터 받아오기
-    @Binding var repeatedDaysOfWeekDict: [String: Bool]
+    @Binding var isRepeating: [Bool]
+    
+    // 요일 이름
+    let daysOfWeek: [String] = ["월요일", "화요일", "수요일", "목요일", "금요일", "토요일", "일요일"]
     
     // 날짜가 선택되었을 때 버튼의 색을 결정하기 위해 subject 값을 받아오기
     var subject: Subject
@@ -26,17 +29,17 @@ struct EditRepeatingDaysOfPromiseView: View {
             
             // 반복 날짜 선택 버튼
             HStack {
-                ForEach(Array(repeatedDaysOfWeekDict.keys), id: \.self) { key in
+                ForEach(daysOfWeek.indices, id: \.self) { index in
                     Button(action: {
-                        repeatedDaysOfWeekDict[key]?.toggle()
+                        isRepeating[index].toggle()
                     }, label: {
                         ZStack {
                             Rectangle()
                                 .frame(width: 100, height: 40)
-                                .foregroundColor(repeatedDaysOfWeekDict[key] ?? false ? getPointColor(subject: subject) : Color.Kkookk.unselectedTabGray)
+                                .foregroundColor(isRepeating[index] ? getPointColor(subject: subject) : Color.Kkookk.unselectedTabGray)
                                 .cornerRadius(10, antialiased:  true)
-                            Text(key)
-                                .foregroundColor(repeatedDaysOfWeekDict[key] ?? false ? Color.Kkookk.commonWhite : Color.Kkookk.commonBlack)
+                            Text(daysOfWeek[index])
+                                .foregroundColor(isRepeating[index] ? Color.Kkookk.commonWhite : Color.Kkookk.commonBlack)
                         }
                     })
                 }

--- a/kko_okk/Views/BoardViews/TodoTab/PromisePopoverElements/PopoverViewAssets.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/PromisePopoverElements/PopoverViewAssets.swift
@@ -1,0 +1,15 @@
+//
+//  PopoverViewAssets.swift
+//  kko_okk
+//
+//  Created by 임성균 on 2022/06/10.
+//
+
+import Foundation
+
+class PopoverViewAssets {
+    let popoverViewfullWidth = KkookkSize.fullWidth - 80 //헤더뷰 전체 길이 - 좌우 패딩 40씩
+    let popoverViewfullheight = KkookkSize.fullHeight * 0.172
+    
+    let popoverViewCellheight = KkookkSize.fullHeight * 0.141
+}


### PR DESCRIPTION
closes #75 

## Motivation 
- 팝오버 창의 요일 버튼 순서가 랜덤으로 등장하는 문제가 있었습니다. 

## Key Changes 
- 요일과 반복 여부를 하나의 Dictionary에 담고 있었는데, Dictionary에는 순서가 없어서 발생하는 문제였습니다.
- 요일과 반복 여부를 별개의 Array로 나눠서 해결했습니다. 