### PR TITLE
Feat[#87] 약속 셀의 "⋮" 버튼에 수정하기 팝오버 연결, [ #88] 합의되지 않은 약속을 삭제하는 기능 추가

### DIFF
--- a/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
@@ -9,8 +9,15 @@ import Foundation
 import SwiftUI
 
 struct ButtonForContract: View {
+    // CoreData 사용을 위해 viewContext 받아오기
+    @Environment(\.managedObjectContext) private var viewContext
+    
+    // 약속, Subject(아이 또는 부모) 받아오기
     var contract: Promise
     var nowSubject: String
+    
+    // Popover 띄우고 닫을 용도
+    @State private var isShowingPopover: Bool = false
     
     var body: some View {
         // Stack을 버튼으로 사용하기 위한 UI
@@ -29,12 +36,21 @@ struct ButtonForContract: View {
                         .padding([.top, .leading, .trailing], 20.0)  // padding 배열 처리
                         .padding(.bottom, 5)
                         .frame(maxWidth: .infinity, alignment: .leading)
-
-                    Image(systemName: "ellipsis")
-                        .rotationEffect(.degrees(90))
-                        .foregroundColor(.white)
-                        .frame(width: 40, height: 40)
-                        .padding(.top, 10)
+                    
+                    Menu {
+                        Button("수정하기") {
+                            
+                        }
+                        Button("삭제하기") {
+                            
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .rotationEffect(.degrees(90))
+                            .foregroundColor(.white)
+                            .frame(width: 40, height: 40)
+                            .padding(.top, 10)
+                    }
                 }
 
                 Text(contract.memo!)  // contract의 memo(하단 자세한 내용)을 받아와서 보여줌
@@ -64,5 +80,9 @@ struct ButtonForContract: View {
             result = contract.subject == "child" ? Color.Kkookk.childGreen : Color.Kkookk.tabDividerGray  // contract.subject가 child인 경우 childGreen, 아니면 tabDividerGray
         }
         return result
+    }
+    
+    private func deletePromise(promise: Promise) {
+        
     }
 }

--- a/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
@@ -14,7 +14,18 @@ struct ButtonForContract: View {
     
     // 약속, Subject(아이 또는 부모) 받아오기
     var contract: Promise
+    
     var nowSubject: String
+    var subject: Subject {
+        switch nowSubject {
+        case "parent":
+            return .parent
+        case "child":
+            return .child
+        default:
+            return .parent
+        }
+    }
     
     // Popover 띄우고 닫을 용도
     @State private var isShowingPopover: Bool = false
@@ -38,12 +49,18 @@ struct ButtonForContract: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                     
                     Menu {
-                        Button("수정하기") {
-                            
+                        Button {
+                            isShowingPopover.toggle()
+                        } label: {
+                            Label("수정하기", systemImage: "pencil")
                         }
-                        Button("삭제하기") {
-                            
+                        
+                        Button(role: .destructive) {
+                            deletePromise(promise: contract)
+                        } label: {
+                            Label("삭제하기", systemImage: "trash")
                         }
+                        
                     } label: {
                         Image(systemName: "ellipsis")
                             .rotationEffect(.degrees(90))
@@ -51,8 +68,11 @@ struct ButtonForContract: View {
                             .frame(width: 40, height: 40)
                             .padding(.top, 10)
                     }
+                    .popover(isPresented: $isShowingPopover) {
+                        EditPromisePopover(subject: subject, promise: contract, isPresented: $isShowingPopover)
+                    }
                 }
-
+                
                 Text(contract.memo!)  // contract의 memo(하단 자세한 내용)을 받아와서 보여줌
                     .font(.system(size: 17, weight: .regular, design: .rounded))
                     .foregroundColor(.white)
@@ -73,7 +93,7 @@ struct ButtonForContract: View {
         // parameter: contract: Promise(Promise 인스턴스), nowList: String (String 타입, 현재 뷰에서 그리는 리스트)
         // contract: Promise 앞의 for, nowList: String 앞의 now는 각각을 for, now로 사용할 수 있도록 하는 신택스 컴포넌트
         var result: Color  // result 변수는 Color 값이 들어감
-
+        
         if nowList == "parent" {  // nowList 값이 parent와 같은 경우
             result = contract.subject == "parent" ? Color.Kkookk.parentPurple : Color.Kkookk.tabDividerGray  // contract.subject가 parent인 경우 parentPurple, 아니면 tabDividerGray
         } else {  // nowList 값이 parent가 아닌 경우

--- a/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
@@ -83,6 +83,16 @@ struct ButtonForContract: View {
     }
     
     private func deletePromise(promise: Promise) {
+        withAnimation {
+            viewContext.delete(promise)
+        }
         
+        // 데이터 저장
+        do {
+            try viewContext.save()
+        } catch {
+            let nsError = error as NSError
+            fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+        }
     }
 }


### PR DESCRIPTION
closes #87 
closes #88 

## Motivation
- 합의되지 않은 약속을 수정, 삭제할 수 있어야 합니다. 
- 수정하기, 삭제하기 버튼을 포함하는 메뉴를 만들어야 합니다. 
- 수정하기 버튼을 누르면 EditPromisePopover 를 띄워야 합니다.

## Results
- 메뉴
<img width="450" alt="image" src="https://user-images.githubusercontent.com/102859746/173299910-681b1f0e-8c61-4469-85be-f8403bd09680.png">

- 수정하기
<img width="450" alt="image" src="https://user-images.githubusercontent.com/102859746/173299947-fc951d1f-fdfd-49d9-8241-9302d146dc98.png">
