### PR TITLE
Feat[#119] 체크마크 크기, 위치, 두께 조정;  Feat[#103] 앱 라이트 모드 고정

### DIFF
--- a/kko-okk-Info.plist
+++ b/kko-okk-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>AppleSDGothicNeoB.ttf</string>

--- a/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
@@ -215,8 +215,7 @@ struct ButtonForContract: View {
                                 .trim(from: /*@START_MENU_TOKEN@*/0.0/*@END_MENU_TOKEN@*/, to: CGFloat(parentShowCheckmark))
                                 .stroke(style: StrokeStyle(lineWidth: 8, lineCap: .round, lineJoin: .round))
                                 .offset(x: 0, y: 0)
-                                // TODO: - deprectated 경고 지우기
-                                .animation(Animation.easeInOut(duration: 0.5).delay(0))
+                                .animation(Animation.easeInOut(duration: 0.5).delay(0), value: parentShowCheckmark)
 //                                .frame(width: geometry.size.width, height: geometry.size.height)
                                 // TODO: - 제스처 크기 하드코딩 수정
                                 .frame(width: 30, height: 30)
@@ -248,8 +247,7 @@ struct ButtonForContract: View {
                                 .trim(from: /*@START_MENU_TOKEN@*/0.0/*@END_MENU_TOKEN@*/, to: CGFloat(childShowCheckmark))
                                 .stroke(style: StrokeStyle(lineWidth: 8, lineCap: .round, lineJoin: .round))
                                 .offset(x: 0, y: 0)
-                                // TODO: - deprectated 경고 지우기
-                                .animation(Animation.easeInOut(duration: 0.5).delay(0))
+                                .animation(Animation.easeInOut(duration: 0.5).delay(0), value: childShowCheckmark)
 //                                .frame(width: geometry.size.width, height: geometry.size.height)
                                 // TODO: - 제스처 크기 하드코딩 수정
                                 .frame(width: 30, height: 30)

--- a/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
@@ -173,10 +173,8 @@ struct ButtonForContract: View {
             }
                 // promised List에서 check 버튼활성화
                 if contract.promised {
-                    // TODO: - 중복되는 코드 묶기
                     VStack{
                         Spacer()
-//                        GeometryReader { geometry in
                             ZStack{
                                 Circle()
                                     .fill(self.isDetachingParentCheck ?
@@ -185,45 +183,21 @@ struct ButtonForContract: View {
                                     .gesture(parentCheckGesture)
 
                                 Path { path in
-                                    // check 각도 테스트
-                                    // origin
-                                    /*
-                                    path.move(to: CGPoint(x: -1, y: -1))
-                                    path.addCurve(
-                                        to: CGPoint(x: 21, y: 26),
-                                        control1: CGPoint(x: -1, y: -1),
-                                        control2: CGPoint(x: 22, y: 26))
-                                    path.addCurve(
-                                        to: CGPoint(x: 56, y: -28),
-                                        control1: CGPoint(x: 20, y: 26),
-                                        control2: CGPoint(x: 56, y: -28))
-                                    path.move(to: CGPoint(x: -1, y: -1))
-                                    */
-                                    
-                                    path.move(to: CGPoint(x: 7, y: 7)) // origin (-1.-1)
-                                    path.addCurve(
-                                        to: CGPoint(x: 18, y: 22), // origin (21.26)
-                                        control1: CGPoint(x: -1, y: -1), // origin (-1.-1)
-                                        control2: CGPoint(x: 18, y: 22)) // origin (22.26)
-                                    path.addCurve(
-                                        to: CGPoint(x: 40, y: -10), // origin (56.-28)
-                                        control1: CGPoint(x: 18, y: 22), // origin (20.26) x: 시작점
-                                        control2: CGPoint(x: 40, y: -10)) // origin (56.-28) x: 꼬리 각도
-                                    path.move(to: CGPoint(x: -1, y: -1)) // origin (-1.-1)
+                                    path.addLines([CGPoint(x: 2, y: 2),
+                                                   CGPoint(x: 9, y: 11),
+                                                   CGPoint(x: 20, y: -5)])
                                      
                                 }
                                 .trim(from: /*@START_MENU_TOKEN@*/0.0/*@END_MENU_TOKEN@*/, to: CGFloat(parentShowCheckmark))
-                                .stroke(style: StrokeStyle(lineWidth: 8, lineCap: .round, lineJoin: .round))
-                                .offset(x: 0, y: 0)
-                                .animation(Animation.easeInOut(duration: 0.5).delay(0), value: parentShowCheckmark)
-//                                .frame(width: geometry.size.width, height: geometry.size.height)
-                                // TODO: - 제스처 크기 하드코딩 수정
-                                .frame(width: 30, height: 30)
+                                .stroke(style: StrokeStyle(lineWidth: 3.5,
+                                                           lineCap: .round,
+                                                           lineJoin: .round))
+                                .offset(x: 6, y: 15)
+                                .animation(Animation.easeInOut(duration: 0.3).delay(0), value: parentShowCheckmark)
                                 .foregroundColor(Color.Kkookk.parentPurple)
 
                             }.padding(.bottom, 7)
-//                        }
-//                        GeometryReader { geometry in
+
                             ZStack{
                                 Circle()
                                     .fill(self.isDetachingChildCheck ?
@@ -232,28 +206,18 @@ struct ButtonForContract: View {
                                     .gesture(childCheckGesture)
 
                                 Path { path in
-                                    path.move(to: CGPoint(x: 7, y: 7)) // origin (-1.-1)
-                                    path.addCurve(
-                                        to: CGPoint(x: 18, y: 22), // origin (21.26)
-                                        control1: CGPoint(x: -1, y: -1), // origin (-1.-1)
-                                        control2: CGPoint(x: 18, y: 22)) // origin (22.26)
-                                    path.addCurve(
-                                        to: CGPoint(x: 40, y: -10), // origin (56.-28)
-                                        control1: CGPoint(x: 18, y: 22), // origin (20.26) x: 시작점
-                                        control2: CGPoint(x: 40, y: -10)) // origin (56.-28) x: 꼬리 각도
-                                    path.move(to: CGPoint(x: -1, y: -1)) // origin (-1.-1)
-
+                                    path.addLines([CGPoint(x: 2, y: 2),
+                                                   CGPoint(x: 9, y: 11),
+                                                   CGPoint(x: 20, y: -5)])
                                 }
                                 .trim(from: /*@START_MENU_TOKEN@*/0.0/*@END_MENU_TOKEN@*/, to: CGFloat(childShowCheckmark))
-                                .stroke(style: StrokeStyle(lineWidth: 8, lineCap: .round, lineJoin: .round))
-                                .offset(x: 0, y: 0)
-                                .animation(Animation.easeInOut(duration: 0.5).delay(0), value: childShowCheckmark)
-//                                .frame(width: geometry.size.width, height: geometry.size.height)
-                                // TODO: - 제스처 크기 하드코딩 수정
-                                .frame(width: 30, height: 30)
+                                .stroke(style: StrokeStyle(lineWidth: 3.5,
+                                                           lineCap: .round,
+                                                           lineJoin: .round))
+                                .offset(x: 6, y: 15)
+                                .animation(Animation.easeInOut(duration: 0.3).delay(0), value: childShowCheckmark)
                                 .foregroundColor(Color.Kkookk.childGreen)
                                 }
-//                        }
                         Spacer()
                     }
                     .frame(width: 35)


### PR DESCRIPTION
## Motivation
- CheckMark 크기, 위치, 두께가 보기에 불편합니다. 
- 기기가 다크모드인 경우 앱 UI 일관성이 깨집니다. 

## Key Changes 
- 체크마크를 Curve가 아닌 Line으로 구성 (더 사용하기 쉽고, 코드가 짧음)
- 체크마크 크기, 위치, 두께 조정
- info.plist 설정을 바꿔서 라이트 모드 고정으로 바꿈