### PR TITLE
Feat[#121] 완료된 약속을 하단에 배치하기; Fix[#125] 약속 합의, 약속 완료 여부가 CoreData에 저장되지 않는 문제 해결

### DIFF
--- a/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
@@ -64,12 +64,15 @@ struct ButtonForContract: View {
                     parentShowCheckmark = 1
                     // Promise Status
                     self.completedParentCheck = true
-                    if completedChildCheck { contract.isDone = true}
+                    
+                    if completedChildCheck { contract.isDone = true }
                 } else {
                     // Animation
                     parentShowCheckmark = 0
                     // Promise Status
                     self.completedParentCheck = false
+                    
+                    contract.isDone = false
                 }
             }
         return longPressGuesture
@@ -90,12 +93,14 @@ struct ButtonForContract: View {
                     childShowCheckmark = 1
                     // Promise Status
                     self.completedChildCheck = true
-                    if completedParentCheck { contract.isDone = true}
+                    if completedParentCheck { contract.isDone = true }
                 } else {
                     // Animation
                     childShowCheckmark = 0
                     // Promise Status
                     self.completedChildCheck = false
+                    
+                    contract.isDone = false
                 }
                 
             }

--- a/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ButtonForContract.swift
@@ -74,6 +74,14 @@ struct ButtonForContract: View {
                     
                     contract.isDone = false
                 }
+                
+                // CoreData 업데이트
+                do {
+                    try viewContext.save()
+                } catch {
+                    let nsError = error as NSError
+                    fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+                }
             }
         return longPressGuesture
     }
@@ -103,6 +111,13 @@ struct ButtonForContract: View {
                     contract.isDone = false
                 }
                 
+                // CoreData 업데이트
+                do {
+                    try viewContext.save()
+                } catch {
+                    let nsError = error as NSError
+                    fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+                }
             }
         return longPressGuesture
     }
@@ -118,6 +133,13 @@ struct ButtonForContract: View {
                 contract.isDone = false
                 contract.promised = true
 
+                // CoreData 업데이트
+                do {
+                    try viewContext.save()
+                } catch {
+                    let nsError = error as NSError
+                    fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+                }
             }
         return longPressGuesture
     }

--- a/kko_okk/Views/BoardViews/TodoTab/ContractView.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/ContractView.swift
@@ -31,7 +31,7 @@ struct ContractView: View {
                 .frame(height: 23)
             Spacer()
             // 약속은 만들어졌지만 완료는 안된 것.
-            FilteredList(filter: "promised", formatter: "promised == TRUE AND isDone == FALSE")
+            FilteredList(filter: "promised", formatter: "promised == TRUE")
         }
     }
 }

--- a/kko_okk/Views/BoardViews/TodoTab/FilteredList.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/FilteredList.swift
@@ -34,7 +34,7 @@ struct FilteredList: View {
     }
     
     init(filter: String, formatter: String) {
-        _fetchRequest = FetchRequest<Promise>(sortDescriptors: [SortDescriptor(\.madeTime, order: .forward)],
+        _fetchRequest = FetchRequest<Promise>(sortDescriptors: [SortDescriptor(\.isDone, order: .forward), SortDescriptor(\.madeTime, order: .forward)],
                                               predicate: NSPredicate(format: formatter),
                                               animation: .default)
         nowSubject = filter


### PR DESCRIPTION
## Motivation 
- 완료된 약속도 계속 볼 수 있었으면 좋겠다는 의견이 있었습니다.
- 앱을 재시작하면 약속 합의, 약속 완료 여부가 리셋되는 문제가 있었습니다. 

## Key Changes 
- 합의된 약속을 불러올 때 완료된 것도 불러오도록 했습니다.
- 부모와 아이가 체크 표시를 하면 맨 아래로 내려가도록 했습니다. 
- 변경 내역이 코어데이터에 저장되도록 했습니다. 