### PR TITLE
Fix[#195]: 아이 약속 만들기를 눌러도 부모 약속 만들기 팝오버가 뜨는 문제 수정

### DIFF
--- a/kko_okk/Views/BoardViews/TodoTab/FilteredList.swift
+++ b/kko_okk/Views/BoardViews/TodoTab/FilteredList.swift
@@ -75,7 +75,18 @@ struct FilteredList: View {
                     
                 }
                 .popover(isPresented: $isShowingPopover) {
-                    AddPromisePopover(subject: .parent, isPresented: $isShowingPopover)
+                    switch nowSubject {
+                    case "parent":
+                        AddPromisePopover(subject: .parent,
+                                          isPresented: $isShowingPopover)
+                    case "child":
+                        AddPromisePopover(subject: .child,
+                                          isPresented: $isShowingPopover)
+                    default:
+                        AddPromisePopover(subject: .parent,
+                                          isPresented: $isShowingPopover)
+                    }
+                    
                 }
             }
             .padding([.leading, .trailing], 10)


### PR DESCRIPTION
## Key Changes
- AddPromisePopover에 subject가 "parent" 고정값이 들어가고 있어서 발생하는 문제였습니다. 
- switch 문으로 처리했습니다. 

## 결과
<img width="784" alt="image" src="https://user-images.githubusercontent.com/102859746/174521937-d355606d-f84a-48f4-9d08-26ade4d402ab.png">
